### PR TITLE
refactor: unify error handling and modernize helpers

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,6 @@
-from flask import Flask, Blueprint, jsonify
+from flask import Blueprint, Flask, jsonify
 from pymongo import MongoClient
+from pymongo.database import Database
 from typing import Type
 import atexit
 
@@ -31,7 +32,7 @@ def create_app(config_object: Type[DefaultConfig] = DefaultConfig) -> Flask:
     _register_blueprints(app, db)
     return app
 
-def _register_blueprints(app: Flask, db):
+def _register_blueprints(app: Flask, db: Database) -> None:
     api_bp = Blueprint("api", __name__, url_prefix="/api")
 
     @api_bp.get("/")

--- a/src/app/auth/controller.py
+++ b/src/app/auth/controller.py
@@ -1,6 +1,8 @@
 from flask import Blueprint, jsonify, request
 from pymongo.database import Database
-from flask_jwt_extended import jwt_required, get_jwt_identity
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from src.helpers.utils import json_error
 from .service import AuthService
 
 def create_auth_router(db: Database) -> Blueprint:
@@ -14,7 +16,7 @@ def create_auth_router(db: Database) -> Blueprint:
         try:
             created = service.register(data)
         except ValueError as e:
-            return jsonify({"error": str(e)}), 400
+            return json_error(str(e))
         
         return jsonify(created), 201
 
@@ -25,7 +27,7 @@ def create_auth_router(db: Database) -> Blueprint:
         try:
             user = service.login(data)
         except ValueError as e:
-            return jsonify({"error": str(e)}), 400
+            return json_error(str(e))
 
         return jsonify(user), 200
     
@@ -37,7 +39,7 @@ def create_auth_router(db: Database) -> Blueprint:
         try:
             user = service.login_token(current_user)
         except ValueError as e:
-            return jsonify({"error": str(e)}), 400
+            return json_error(str(e))
 
         return jsonify(user), 200
     
@@ -45,7 +47,7 @@ def create_auth_router(db: Database) -> Blueprint:
     def email_exists():
         email = request.args.get("email")
         if not email:
-            return jsonify({"error": "Email parameter is required"}), 400
+            return json_error("Email parameter is required")
         
         exists = service.email_exists(email)
         return jsonify({"exists": exists}), 200

--- a/src/app/configurations/controller.py
+++ b/src/app/configurations/controller.py
@@ -1,7 +1,8 @@
 from flask import Blueprint, jsonify, request
 from pymongo.database import Database
-from flask_jwt_extended import jwt_required, get_jwt_identity, get_jwt
-from src.app.models import service
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from src.helpers.utils import json_error
 from .service import ConfigurationsService
 
 def create_configurations_router(db: Database) -> Blueprint:
@@ -13,17 +14,17 @@ def create_configurations_router(db: Database) -> Blueprint:
     def find_configurations():
         docs = service.find_all()
         if not docs:
-            return jsonify({"error": "Not found"}), 404
+            return json_error("Not found", 404)
         return jsonify(docs), 200
 
     @bp.post("/")
     @jwt_required()
     def create_configuration():
         user_id = get_jwt_identity()
-        data = request.json
-        if not data:
-            return jsonify({"error": "Bad request"}), 400
-        configuration = service.create(user_id, data)
+        payload = request.get_json(silent=True)
+        if not payload:
+            return json_error("Bad request")
+        configuration = service.create(user_id, payload)
         return jsonify(configuration), 201
     
     @bp.get("/<id>")
@@ -31,7 +32,7 @@ def create_configurations_router(db: Database) -> Blueprint:
     def get_configuration(id):
         doc = service.find_one_by_id(id)
         if not doc:
-            return jsonify({"error": "Not found"}), 404
+            return json_error("Not found", 404)
         return jsonify(doc), 200
 
     return bp

--- a/src/app/models/controller.py
+++ b/src/app/models/controller.py
@@ -1,6 +1,8 @@
 from flask import Blueprint, jsonify, request
 from pymongo.database import Database
-from flask_jwt_extended import jwt_required, get_jwt_identity, get_jwt
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from src.helpers.utils import json_error
 from .service import ModelsService
 
 def create_models_router(db: Database) -> Blueprint:
@@ -12,27 +14,27 @@ def create_models_router(db: Database) -> Blueprint:
     def find_models():
         docs = service.find_all()
         if not docs:
-            return jsonify({"error": "Not found"}), 404
+            return json_error("Not found", 404)
         return jsonify(docs), 200
     
     @bp.post("/")
     @jwt_required()
     def create_model():
         user_id = get_jwt_identity()
-        data = request.json
-        if not data:
-            return jsonify({"error": "Bad request"}), 400
-        model = service.create(user_id, data)
+        payload = request.get_json(silent=True)
+        if not payload:
+            return json_error("Bad request")
+        model = service.create(user_id, payload)
         return jsonify(model), 201
     
     @bp.post("/build/<model_id>")
     @jwt_required()
     def build_model(model_id):
         try:
-            parameters = request.json or {}
+            parameters = request.get_json(silent=True) or {}
             model = service.build_model(model_id, parameters)
             return jsonify(model), 200
         except ValueError as e:
-            return jsonify({"error": str(e)}), 400
+            return json_error(str(e))
 
     return bp

--- a/src/app/playgrounds/controller.py
+++ b/src/app/playgrounds/controller.py
@@ -1,7 +1,8 @@
 from flask import Blueprint, jsonify, request
 from pymongo.database import Database
-from flask_jwt_extended import jwt_required, get_jwt_identity
+from flask_jwt_extended import get_jwt_identity, jwt_required
 
+from src.helpers.utils import json_error
 from .service import PlaygroundsService
 
 def create_playgrounds_router(db: Database) -> Blueprint:
@@ -13,18 +14,18 @@ def create_playgrounds_router(db: Database) -> Blueprint:
     def find_playgrounds_for_user():
         playgrounds = service.find_by_user_id(get_jwt_identity())
         if not playgrounds:
-            return jsonify({"error": "Not found"}), 404
+            return json_error("Not found", 404)
         return jsonify(playgrounds), 200
 
     @bp.post("/")
     @jwt_required()
     def create_playground():
-        data = request.get_json() or {}
+        data = request.get_json(silent=True) or {}
         user_id = get_jwt_identity()
         try:
             playground = service.create_playground(user_id, data)
         except ValueError as e:
-            return jsonify({"error": str(e)}), 400
+            return json_error(str(e))
         return jsonify(playground), 201
     
     return bp

--- a/src/app/users/controller.py
+++ b/src/app/users/controller.py
@@ -1,6 +1,8 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify
 from pymongo.database import Database
-from flask_jwt_extended import jwt_required, get_jwt_identity
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from src.helpers.utils import json_error
 from .service import UsersService
 
 def create_users_router(db: Database) -> Blueprint:
@@ -17,7 +19,7 @@ def create_users_router(db: Database) -> Blueprint:
     def find_me():
         user = service.find_user_by_id(get_jwt_identity())
         if not user:
-            return jsonify({"error": "Not found"}), 404
+            return json_error("Not found", 404)
         return jsonify(user), 200
     
     @bp.put("/me/avatar")

--- a/src/helpers/base_service.py
+++ b/src/helpers/base_service.py
@@ -1,5 +1,12 @@
+"""Base class for service layers."""
+
+from dataclasses import dataclass
 from pymongo.database import Database
 
+
+@dataclass(slots=True)
 class BaseService:
-    def __init__(self, db: Database) -> None:
-        self.db = db
+    """Simple container for the Mongo database instance."""
+
+    db: Database
+

--- a/src/helpers/utils.py
+++ b/src/helpers/utils.py
@@ -1,8 +1,33 @@
+"""Utility helpers for the API."""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+from flask import jsonify
+
+
+def json_error(message: str, status: int = 400) -> Tuple[Any, int]:
+    """Return a JSON error response with the given status code."""
+    return jsonify({"error": message}), status
+
+
 def bump_version(version: str, bump: str) -> str:
+    """Bump a semantic version string.
+
+    Parameters
+    ----------
+    version:
+        Current version string in the form ``"major.minor"``.
+    bump:
+        Either ``"major"`` or ``"minor"`` indicating which part to bump.
+
+    Returns
+    -------
+    str
+        The bumped version string.
+    """
+
     major, minor = map(int, version.split("."))
     if bump == "major":
-        major += 1
-        minor = 0
-    else:
-        minor += 1
-    return f"{major}.{minor}"
+        return f"{major + 1}.0"
+    return f"{major}.{minor + 1}"


### PR DESCRIPTION
## Summary
- centralize error responses with new `json_error` utility
- modernize base DAO/Service using `dataclass` and slots
- adopt helper in controllers for clearer request parsing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b320c72e18832a87e339e94311351d